### PR TITLE
feat: fix lag animations and tech moving

### DIFF
--- a/src/components/ExpandableCards/index.tsx
+++ b/src/components/ExpandableCards/index.tsx
@@ -65,8 +65,7 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
               initial={{ opacity: 0, scale: 0.8 }}
               animate={{ opacity: 1, scale: 1 }}
               exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.2, ease: "easeOut" }}
-              className="flex absolute top-2 right-2 lg:hidden items-center justify-center z-[100] bg-white rounded-full h-6 w-6"
+              className="flex absolute duration-[0.2] ease-in-out top-2 right-2 lg:hidden items-center justify-center z-[100] bg-white rounded-full h-6 w-6"
               onClick={() => setActive(null)}
               style={{ willChange: "transform, opacity" }}
             >
@@ -75,9 +74,8 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
             <motion.div
               layoutId={`card-${active.title}-${id}`}
               ref={ref}
-              className="w-full max-w-[700px] h-full md:h-fit md:max-h-[90%] flex flex-col bg-white dark:bg-neutral-900 sm:rounded-lg overflow-auto md:overflow-hidden"
+              className="w-full transition-0-3s max-w-[700px] h-full md:h-fit md:max-h-[90%] flex flex-col bg-white dark:bg-neutral-900 sm:rounded-lg overflow-auto md:overflow-hidden"
               style={{ willChange: "transform" }}
-              transition={{ duration: 0.3, ease: "easeInOut" }}
             >
               <motion.div
                 layoutId={`image-${active.title}-${id}`}
@@ -117,10 +115,9 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
                     <motion.a
                       initial={{ opacity: 0, y: 20 }}
                       animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: 0.2, duration: 0.2 }}
                       href={active.ctaLink}
                       target="_blank"
-                      className="relative inline-flex h-8 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50"
+                      className="relative delay-[0.2] duration-[0.2] inline-flex h-8 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50"
                       style={{ willChange: "transform, opacity" }}
                     >
                       <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#CBE8FF_0%,#3988B2_50%,#CBE8FF_100%)]" />
@@ -138,8 +135,7 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 20 }}
-                    transition={{ delay: 0.1, duration: 0.3 }}
-                    className="text-sm lg:text-base h-auto md:h-[30rem] pb-10 flex flex-col items-start gap-4 md:overflow-scroll [scrollbar-width:none] [-ms-overflow-style:none] [-webkit-overflow-scrolling:touch]"
+                    className="text-sm lg:text-base delay-[0.1] duration-[0.3] h-auto md:h-[30rem] pb-10 flex flex-col items-start gap-4 md:overflow-scroll [scrollbar-width:none] [-ms-overflow-style:none] [-webkit-overflow-scrolling:touch]"
                     style={{ willChange: "transform, opacity" }}
                   >
                     {typeof active.content === "function"
@@ -160,12 +156,7 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
             onClick={() => setActive(card)}
             whileHover={{ y: -5 }}
             whileTap={{ scale: 0.98 }}
-            transition={{
-              duration: 0.2,
-              ease: "easeOut",
-              layout: { duration: 0.3, ease: "easeInOut" },
-            }}
-            className="flex flex-col justify-between bg-card items-center rounded-md cursor-pointer border dark:border-neutral-700 overflow-hidden transform-gpu"
+            className="flex flex-col duration-[0.2] ease-out  justify-between bg-card items-center rounded-md cursor-pointer border dark:border-neutral-700 overflow-hidden transform-gpu"
             style={{ willChange: "transform" }}
           >
             <motion.div
@@ -215,9 +206,8 @@ function ExpandableCard({ cards }: ExpandableCardProps) {
               </div>
               <div>
                 <motion.button
-                  className="text-sm rounded-full flex items-center gap-1 cursor-pointer"
+                  className="text-sm duration-[0.1] rounded-full flex items-center gap-1 cursor-pointer"
                   whileTap={{ scale: 0.95 }}
-                  transition={{ duration: 0.1 }}
                 >
                   Read more
                   <Icon family="Lucide" name="LuArrowRight" size={18} />
@@ -237,7 +227,6 @@ export const CloseIcon = () => {
       initial={{ opacity: 0, rotate: -90 }}
       animate={{ opacity: 1, rotate: 0 }}
       exit={{ opacity: 0, rotate: 90 }}
-      transition={{ duration: 0.2 }}
       xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
@@ -247,7 +236,7 @@ export const CloseIcon = () => {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="h-4 w-4 text-black"
+      className="h-4 w-4 text-black duration-[0.2]"
       style={{ willChange: "transform, opacity" }}
     >
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/src/components/GridBackground/index.tsx
+++ b/src/components/GridBackground/index.tsx
@@ -31,7 +31,7 @@ function GridBackgroundDemo({ title }: GridBackgroundProps) {
           scale: 1,
           transition: { duration: 0.6, ease: "easeOut" },
         }}
-        className="w-[90%] flex flex-col items-center gap-4 z-20"
+        className="w-[90%] duration-[0.6] ease-out flex flex-col items-center gap-4 z-20"
       >
         <div className="flex items-center md:gap-4 flex-wrap justify-center">
           <span className="text-5xl sm:text-7xl font-regular text-foreground">

--- a/src/components/MovingTechs/index.tsx
+++ b/src/components/MovingTechs/index.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { cn } from "@/lib/utils";
 import React, { useEffect, useState, type ReactNode } from "react";
 
@@ -82,8 +80,8 @@ const MovingTechs = ({
           pauseOnHover && "hover:[animation-play-state:paused]"
         )}
       >
-        {items.map((item, idx) => (
-          <li className="relative shrink-0 " key={idx}>
+        {[...items, ...items].map((item, idx) => (
+          <li className="relative shrink-0" key={idx}>
             {item}
           </li>
         ))}

--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,11 @@ body {
   animation: var(--animate-scroll);
 }
 
+.transition0-3s {
+  transition-duration: 0.3s;
+  animation: ease-in-out;
+}
+
 @keyframes move {
   0% {
     transform: translateX(-200px);


### PR DESCRIPTION
This pull request primarily refactors how animation and transition styles are applied to components in the `ExpandableCards`, `GridBackground`, and `MovingTechs` components. The main change is moving transition and animation timing from Framer Motion's `transition` prop to Tailwind CSS utility classes, resulting in more consistent and maintainable styling. Additionally, there are minor improvements to the `MovingTechs` component's rendering logic and some cleanup.

**Transition and Animation Refactoring:**

* Replaced Framer Motion `transition` props with Tailwind CSS utility classes for duration, delay, and easing on key elements in `ExpandableCards` and `GridBackground` components, improving consistency and maintainability of animation styles. [[1]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL68-R68) [[2]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL78-L80) [[3]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL120-R120) [[4]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL141-R138) [[5]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL163-R159) [[6]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL218-L220) [[7]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL240) [[8]](diffhunk://#diff-e83667749da1abd7d601e20b1a4f0b6c52fb197c451cfce63c9d9f5a22b9132aL250-R239) [[9]](diffhunk://#diff-5e26946c26248c151a28b0072b169a8acf03b770e8455e585d9c092de3e030bfL34-R34)

* Added a new `.transition0-3s` CSS class for a 0.3s transition duration and ease-in-out animation in `src/index.css`.

**Component Logic Improvements:**

* Updated `MovingTechs` to render a doubled list (`[...items, ...items]`) for smoother infinite scrolling, instead of a single pass through `items`.

**Minor Cleanup:**

* Removed the `"use client";` directive from `MovingTechs`, as it is not necessary in this context.